### PR TITLE
Added PHSPSplit utility app

### DIFF
--- a/PHSPSplit.cc
+++ b/PHSPSplit.cc
@@ -1,0 +1,214 @@
+
+#include <iostream>
+#include <string>
+#include <chrono>
+#include <filesystem>
+#include <sstream>
+#include <iomanip>
+#include <memory>
+
+#include "particlezoo/utilities/argParse.h"
+#include "particlezoo/utilities/formats.h"
+#include "particlezoo/utilities/progress.h"
+#include "particlezoo/PhaseSpaceFileReader.h"
+#include "particlezoo/PhaseSpaceFileWriter.h"
+
+int main(int argc, char* argv[]) {
+
+    // Initial setup
+    using namespace ParticleZoo;
+    int errorCode = 0;
+
+    // Custom command line arguments
+    const CLICommand SPLIT_NUMBER_COMMAND = CLICommand(NONE, "n", "splitNumber", "Number of files to split this phase space file into", { CLI_INT });
+    const CLICommand INPUT_FORMAT_COMMAND = CLICommand(NONE, "", "inputFormat", "Force input file format (default: auto-detect from extension)", { CLI_STRING });
+    const CLICommand OUTPUT_FORMAT_COMMAND = CLICommand(NONE, "", "outputFormat", "Force output file format (default: auto-detect from extension)", { CLI_STRING });
+    ArgParser::RegisterCommand(SPLIT_NUMBER_COMMAND);
+    ArgParser::RegisterCommand(INPUT_FORMAT_COMMAND);
+    ArgParser::RegisterCommand(OUTPUT_FORMAT_COMMAND);
+    
+    // Define usage message and parse command line arguments
+    std::string usageMessage = "Usage: PHSPSplit [OPTIONS] <inputfile>\n"
+                            "\n"
+                            "Split a single phase space file into multiple equally sized phase space files\n"
+                            "\n"
+                            "Required Arguments:\n"
+                            "  --splitNumber             Number of files to split this phase space file into\n"
+                            "  <inputfile>               Input phase space file to split\n"
+                            "\n"
+                            "Examples:\n"
+                            "  PHSPSplit --splitNumber 10 input.egsphsp\n"
+                            "  PHSPSplit -n 10 input.egsphsp\n"
+                            "  PHSPSplit --outputFormat EGS -n 5 input.IAEAphsp\n"
+                            "  PHSPSplit --formats";
+    auto userOptions = ArgParser::ParseArgs(argc, argv, usageMessage, 1);
+
+    // Validate parameters
+    std::vector<CLIValue> positionals = userOptions.contains(CLI_POSITIONALS) ? userOptions.at(CLI_POSITIONALS) : std::vector<CLIValue>{ "" };
+    std::string inputFile = std::get<std::string>(positionals[0]);
+    std::string inputFormat = userOptions.contains(INPUT_FORMAT_COMMAND) ? (userOptions.at(INPUT_FORMAT_COMMAND).empty() ? "" : std::get<std::string>(userOptions.at(INPUT_FORMAT_COMMAND)[0])) : "";
+    std::string outputFormat = userOptions.contains(OUTPUT_FORMAT_COMMAND) ? (userOptions.at(OUTPUT_FORMAT_COMMAND).empty() ? "" : std::get<std::string>(userOptions.at(OUTPUT_FORMAT_COMMAND)[0])) : "";
+    int splitNumber = userOptions.contains(SPLIT_NUMBER_COMMAND) ? (userOptions.at(SPLIT_NUMBER_COMMAND).empty() ? -1 : std::get<int>(userOptions.at(SPLIT_NUMBER_COMMAND)[0])) : -1;
+
+    if (inputFile.empty()) {
+        std::cerr << "Error: No input file specified\n";
+        errorCode = 1;
+        return errorCode;
+    }
+
+    if (splitNumber <= 1) {
+        std::cerr << "Error: Invalid split number (" << splitNumber << "). Must be an integer > 1\n";
+        errorCode = 1;
+        return errorCode;
+    }
+
+    // Check file name before extension and get output file extension based on phase space format
+    auto inputPath = std::filesystem::path(inputFile);
+    auto fileStem = inputPath.stem().string(); // get filename without extension
+    auto fileExt = outputFormat.length() == 0 ? inputPath.extension().string() : FormatRegistry::ExtensionForFormat(outputFormat);
+
+    if (fileStem.empty() || fileExt.empty()) {
+        std::cerr << "Error: Invalid input file name (" << inputFile << ")\n";
+        errorCode = 1;
+        return errorCode;
+    }
+
+    auto GetSplitFilePath = [&](int index) {
+        index++; // make 1-based index
+
+        // Construct new filename with numbered suffix before the extension
+        // The number should have leading zeros based on the total number of files
+        std::ostringstream ss;
+        ss << std::setw(std::to_string(splitNumber).length()) << std::setfill('0') << index;
+        std::string numbered = fileStem + "_Part" + ss.str() + fileExt;
+
+        return (inputPath.parent_path() / numbered).string();
+    };
+
+    // Start timer
+    auto startTime = std::chrono::high_resolution_clock::now();
+
+    // Create reader and writer pointers
+    std::unique_ptr<PhaseSpaceFileReader> reader;
+    std::unique_ptr<PhaseSpaceFileWriter> writer;
+
+    try {
+
+        // Create the reader for the input file
+        if (inputFormat.empty()) {
+            reader = FormatRegistry::CreateReader(inputFile, userOptions);
+        } else {
+            reader = FormatRegistry::CreateReader(inputFormat, inputFile, userOptions);
+        }
+
+        // Try to keep the same constant values in the new phase space file if it supports them
+        FixedValues fixedValues = reader->getFixedValues();
+
+        std::uint64_t totalParticles = reader->getNumberOfParticles();
+        if (totalParticles == 0) {
+            std::cerr << "Error: Input file contains no particles\n";
+            errorCode = 1;
+            if (reader) reader->close();
+            return errorCode;
+        }
+        if (totalParticles < static_cast<std::uint64_t>(splitNumber)) {
+            std::cerr << "Error: Input file contains fewer particles (" << totalParticles << ") than the requested split number (" << splitNumber << ")\n";
+            errorCode = 1;
+            if (reader) reader->close();
+            return errorCode;
+        }
+
+        // Calculate the number of particles per split file
+        std::uint64_t particlesPerSplit = totalParticles / splitNumber;
+
+        // Split the phase space file
+        int filesSplit = 0;
+
+        std::string outputFilePath = GetSplitFilePath(0);
+
+        if (outputFormat.empty()) {
+            writer = FormatRegistry::CreateWriter(outputFilePath, userOptions, fixedValues);
+        } else {
+            writer = FormatRegistry::CreateWriter(outputFormat, outputFilePath, userOptions, fixedValues);
+        }
+
+        // Determine progress update interval
+        uint64_t onePercentInterval = particlesPerSplit >= 100 
+                                    ? particlesPerSplit / 100 
+                                    : 1;
+
+        std::cout << "Splitting particles from " 
+                  << inputFile << " (" << reader->getPHSPFormat() << ") into "
+                  << splitNumber << " parts each with format " << writer->getPHSPFormat() << "..." << std::endl;
+
+        std::uint64_t particlesWrittenAtStartOfSplit = 0;
+        // Loop over the number of files to create
+        for (filesSplit = 0; filesSplit < splitNumber; filesSplit++) {
+            // Reset counters and flags for this split
+            bool isNewHistory = false;
+            bool belowLimit = true;
+            bool isLastFile = (filesSplit == splitNumber - 1);
+
+            Progress<uint64_t> progress(particlesPerSplit);
+            progress.Start(outputFilePath);
+
+            // Buffer the last particle read so that it can be written to the next file if needed
+            Particle particle;
+
+            // Loop until we reach the particle limit for this file, ensuring we don't split a history across files and exceeding the limit for the last file if there are remaining particles
+            for (std::uint64_t j = particlesWrittenAtStartOfSplit; reader->hasMoreParticles() && (belowLimit || !isNewHistory || isLastFile); j++) {
+                // Read the next particle
+                particle = reader->getNextParticle();
+                // Check if this is a new history
+                isNewHistory = particle.isNewHistory();
+                // Write the particle if we are below the limit, or if we're not below the limit but it's not a new history (to avoid splitting histories), or if it's the last file (to write any remaining particles)
+                if (belowLimit || !isNewHistory || isLastFile) {
+                    writer->writeParticle(particle);
+                }
+                // Update the below limit flag for the next iteration
+                belowLimit = (j+1 < particlesPerSplit);
+
+                if (j % onePercentInterval == 0) {
+                    progress.Update(j, "Processed " + std::to_string(writer->getHistoriesWritten()) + " histories.");
+                }
+            }
+
+            // Complete the progress bar for this file
+            progress.Complete("Done. Processed " + std::to_string(writer->getHistoriesWritten()) + " histories.");
+
+            // Close the current output file
+            writer->close();
+            writer = nullptr;
+
+            // If this is not the last file, create a new writer for the next output file and write the last buffered particle to it
+            if (!isLastFile) {
+                // Prepare for next output file
+                outputFilePath = GetSplitFilePath(filesSplit+1);
+                if (outputFormat.empty()) {
+                    writer = FormatRegistry::CreateWriter(outputFilePath, userOptions, fixedValues);
+                } else {
+                    writer = FormatRegistry::CreateWriter(outputFormat, outputFilePath, userOptions, fixedValues);
+                }
+                // Write the last particle read to the new file
+                writer->writeParticle(particle);
+                particlesWrittenAtStartOfSplit = 1;
+            }
+        }
+
+        // End timer and print elapsed time
+        auto endTime = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double> elapsedSeconds = endTime - startTime;
+        std::cout << "Split completed in " << elapsedSeconds.count() << " seconds\n";
+
+    } catch (const std::exception & e) {
+        std::cerr << std::endl << "Error occurred: " << e.what() << std::endl;
+        errorCode = 1;
+    }
+
+    // Close reader
+    if (reader) reader->close();
+    if (writer) writer->close();
+
+    // Return appropriate error code
+    return errorCode;
+}

--- a/README.md
+++ b/README.md
@@ -334,6 +334,18 @@ PHSPImage --projectTo 100 beam.egsphsp projection.tiff
 PHSPImage --outputFormat BMP --projectionType none --plane XZ --planeLocation 5.0 --energyWeighted simulation.IAEAphsp dose_profile.bmp
 ```
 
+### PHSPSplit - File Splitting
+
+Split a single phase space file into multiple equally sized files.
+
+```bash
+# Split a file into multiple parts
+PHSPSplit --splitNumber 10 input.egsphsp
+
+# Use short flag and specify output format
+PHSPSplit -n 5 --outputFormat IAEA input.egsphsp
+```
+
 ## Extending the Library
 
 ### Adding New Formats

--- a/build.bat
+++ b/build.bat
@@ -106,81 +106,81 @@ if /I "%BUILD_TYPE%"=="debug" (
     
     REM --- Static library ---
     echo Building Debug static library...
+    set "OBJ_LIST="
     cl.exe /EHsc /std:c++20 /Od /Ob0 /Zi /W4 /WX /Fo"%OUTDIR%\\" %INCLUDES% %ROOT_FLAGS% /c %LIB_SRCS%
-    lib.exe /OUT:%OUTDIR%\%LIB_NAME% %OUTDIR%\*.obj
+    for %%F in (%COMMON_SRCS%) do (
+      set "OBJ_LIST=!OBJ_LIST! %OUTDIR%\%%~nF.obj"
+    )    
+    lib.exe /OUT:%OUTDIR%\%LIB_NAME% !OBJ_LIST!
     
     REM --- PHSPConvert.exe ---
     echo Building Debug PHSPConvert...
-    cl.exe /EHsc /std:c++20 /Od /Ob0 /Zi /W4 /WX /Fo"%OUTDIR%\\" ^
+    cl.exe /EHsc /std:c++20 /Od /Ob0 /Zi /W4 /WX /Fo"%OUTDIR%\\" /Fe"%OUTDIR%\\PHSPConvert.exe" ^
       %INCLUDES% %ROOT_FLAGS% ^
-      %COMMON_SRCS% PHSPConvert.cc ^
-      /link /DEBUG /OUT:%OUTDIR%\PHSPConvert.exe %ROOT_LIBS%
+      %COMMON_SRCS% PHSPConvert.cc %ROOT_LIBS%
 
     REM --- PHSPCombine.exe ---
     echo Building Debug PHSPCombine...
-    cl.exe /EHsc /std:c++20 /Od /Ob0 /Zi /W4 /WX /Fo"%OUTDIR%\\" ^
+    cl.exe /EHsc /std:c++20 /Od /Ob0 /Zi /W4 /WX /Fo"%OUTDIR%\\" /Fe"%OUTDIR%\\PHSPCombine.exe" ^
       %INCLUDES% %ROOT_FLAGS% ^
-      %COMMON_SRCS% PHSPCombine.cc ^
-      /link /DEBUG /OUT:%OUTDIR%\PHSPCombine.exe %ROOT_LIBS%
+      %COMMON_SRCS% PHSPCombine.cc %ROOT_LIBS%
       
     REM --- PHSPImage.exe ---
     echo Building Debug PHSPImage...
-    cl.exe /EHsc /std:c++20 /Od /Ob0 /Zi /W4 /WX /Fo"%OUTDIR%\\" ^
+    cl.exe /EHsc /std:c++20 /Od /Ob0 /Zi /W4 /WX /Fo"%OUTDIR%\\" /Fe"%OUTDIR%\\PHSPImage.exe" ^
       %INCLUDES% %ROOT_FLAGS% ^
-      %COMMON_SRCS% PHSPImage.cc ^
-      /link /DEBUG /OUT:%OUTDIR%\PHSPImage.exe %ROOT_LIBS%      
+      %COMMON_SRCS% PHSPImage.cc %ROOT_LIBS%
 
     REM --- PHSPSplit.exe ---
     echo Building Debug PHSPSplit...
-    cl.exe /EHsc /std:c++20 /Od /Ob0 /Zi /W4 /WX /Fo"%OUTDIR%\\" ^
+    cl.exe /EHsc /std:c++20 /Od /Ob0 /Zi /W4 /WX /Fo"%OUTDIR%\\" /Fe"%OUTDIR%\\PHSPSplit.exe" ^
       %INCLUDES% %ROOT_FLAGS% ^
-      %COMMON_SRCS% PHSPSplit.cc ^
-      /link /DEBUG /OUT:%OUTDIR%\PHSPSplit.exe %ROOT_LIBS%
+      %COMMON_SRCS% PHSPSplit.cc %ROOT_LIBS%
 
     REM --- Dynamic library (.dll) ---
     if not exist "%OUTDIR%\bin" mkdir "%OUTDIR%\bin"
     echo Building Debug dynamic library...
-    cl.exe /EHsc /std:c++20 /Od /Ob0 /Zi /W4 /WX %INCLUDES% %ROOT_FLAGS% /LD %LIB_SRCS% /link /OUT:%OUTDIR%\bin\particlezoo.dll %ROOT_LIBS%
+    cl.exe /EHsc /std:c++20 /Od /Ob0 /Zi /W4 /WX %INCLUDES% %ROOT_FLAGS% /LD %LIB_SRCS% /Fe"%OUTDIR%\\bin\\particlezoo.dll" %ROOT_LIBS%
 
 ) else (
     echo Release build.
     
     REM --- Static library ---
     echo Building Release static library...
+    set "OBJ_LIST="
     cl.exe /EHsc /std:c++20 /O2 /Ob2 /W4 /WX /Fo"%OUTDIR%\\" %INCLUDES% %ROOT_FLAGS% /c %LIB_SRCS%
-    lib.exe /OUT:%OUTDIR%\%LIB_NAME% %OUTDIR%\*.obj
+    for %%F in (%COMMON_SRCS%) do (
+      set "OBJ_LIST=!OBJ_LIST! %OUTDIR%\%%~nF.obj"
+    )
+    lib.exe /OUT:%OUTDIR%\%LIB_NAME% !OBJ_LIST!
     
     REM --- PHSPConvert.exe ---
     echo Building Release PHSPConvert...
-    cl.exe /EHsc /std:c++20 /O2 /Ob2 /W4 /WX /Fo"%OUTDIR%\\" ^
+    cl.exe /EHsc /std:c++20 /O2 /Ob2 /W4 /WX /Fo"%OUTDIR%\\" /Fe"%OUTDIR%\\PHSPConvert.exe" ^
       %INCLUDES% %ROOT_FLAGS% ^
-      %COMMON_SRCS% PHSPConvert.cc ^
-      /link /OUT:%OUTDIR%\PHSPConvert.exe %ROOT_LIBS%
+      %COMMON_SRCS% PHSPConvert.cc %ROOT_LIBS%
 
     REM --- PHSPCombine.exe ---
     echo Building Release PHSPCombine...
-    cl.exe /EHsc /std:c++20 /O2 /Ob2 /W4 /WX /Fo"%OUTDIR%\\" ^
+    cl.exe /EHsc /std:c++20 /O2 /Ob2 /W4 /WX /Fo"%OUTDIR%\\" /Fe"%OUTDIR%\\PHSPCombine.exe" ^
       %INCLUDES% %ROOT_FLAGS% ^
-      %COMMON_SRCS% PHSPCombine.cc ^
-      /link /OUT:%OUTDIR%\PHSPCombine.exe %ROOT_LIBS%
+      %COMMON_SRCS% PHSPCombine.cc %ROOT_LIBS%
       
     REM --- PHSPImage.exe ---
     echo Building Release PHSPImage...
-    cl.exe /EHsc /std:c++20 /O2 /Ob2 /W4 /WX /Fo"%OUTDIR%\\" ^
+    cl.exe /EHsc /std:c++20 /O2 /Ob2 /W4 /WX /Fo"%OUTDIR%\\" /Fe"%OUTDIR%\\PHSPImage.exe" ^
       %INCLUDES% %ROOT_FLAGS% ^
-      %COMMON_SRCS% PHSPImage.cc ^
-      /link /OUT:%OUTDIR%\PHSPImage.exe %ROOT_LIBS%
-      
+      %COMMON_SRCS% PHSPImage.cc %ROOT_LIBS%
+
     REM --- PHSPSplit.exe ---
     echo Building Release PHSPSplit...
-    cl.exe /EHsc /std:c++20 /O2 /Ob2 /W4 /WX /Fo"%OUTDIR%\\" ^
+    cl.exe /EHsc /std:c++20 /O2 /Ob2 /W4 /WX /Fo"%OUTDIR%\\" /Fe"%OUTDIR%\\PHSPSplit.exe" ^
       %INCLUDES% %ROOT_FLAGS% ^
-      %COMMON_SRCS% PHSPSplit.cc ^
-      /link /OUT:%OUTDIR%\PHSPSplit.exe %ROOT_LIBS%
+      %COMMON_SRCS% PHSPSplit.cc %ROOT_LIBS%
 
     REM --- Dynamic library (.dll) ---
     echo Building Release dynamic library...
-    cl.exe /EHsc /std:c++20 /O2 /Ob2 /W4 /WX %INCLUDES% %ROOT_FLAGS% /LD %LIB_SRCS% /link /OUT:%OUTDIR%\particlezoo.dll %ROOT_LIBS%
+    cl.exe /EHsc /std:c++20 /O2 /Ob2 /W4 /WX %INCLUDES% %ROOT_FLAGS% /LD %LIB_SRCS% /Fe"%OUTDIR%\\particlezoo.dll" %ROOT_LIBS%
 )
 
 if %ERRORLEVEL%==0 (

--- a/build.bat
+++ b/build.bat
@@ -128,7 +128,14 @@ if /I "%BUILD_TYPE%"=="debug" (
     cl.exe /EHsc /std:c++20 /Od /Ob0 /Zi /W4 /WX /Fo"%OUTDIR%\\" ^
       %INCLUDES% %ROOT_FLAGS% ^
       %COMMON_SRCS% PHSPImage.cc ^
-      /link /DEBUG /OUT:%OUTDIR%\PHSPImage.exe %ROOT_LIBS%
+      /link /DEBUG /OUT:%OUTDIR%\PHSPImage.exe %ROOT_LIBS%      
+
+    REM --- PHSPSplit.exe ---
+    echo Building Debug PHSPSplit...
+    cl.exe /EHsc /std:c++20 /Od /Ob0 /Zi /W4 /WX /Fo"%OUTDIR%\\" ^
+      %INCLUDES% %ROOT_FLAGS% ^
+      %COMMON_SRCS% PHSPSplit.cc ^
+      /link /DEBUG /OUT:%OUTDIR%\PHSPSplit.exe %ROOT_LIBS%
 
     REM --- Dynamic library (.dll) ---
     if not exist "%OUTDIR%\bin" mkdir "%OUTDIR%\bin"
@@ -163,6 +170,13 @@ if /I "%BUILD_TYPE%"=="debug" (
       %INCLUDES% %ROOT_FLAGS% ^
       %COMMON_SRCS% PHSPImage.cc ^
       /link /OUT:%OUTDIR%\PHSPImage.exe %ROOT_LIBS%
+      
+    REM --- PHSPSplit.exe ---
+    echo Building Release PHSPSplit...
+    cl.exe /EHsc /std:c++20 /O2 /Ob2 /W4 /WX /Fo"%OUTDIR%\\" ^
+      %INCLUDES% %ROOT_FLAGS% ^
+      %COMMON_SRCS% PHSPSplit.cc ^
+      /link /OUT:%OUTDIR%\PHSPSplit.exe %ROOT_LIBS%
 
     REM --- Dynamic library (.dll) ---
     echo Building Release dynamic library...
@@ -175,7 +189,7 @@ if %ERRORLEVEL%==0 (
     echo Build successful.
     echo.
     echo Build artifacts can be found in: %CD%\%OUTDIR%
-    echo   - Executables: PHSPConvert.exe, PHSPCombine.exe, PHSPImage.exe
+    echo   - Executables: PHSPConvert.exe, PHSPCombine.exe, PHSPImage.exe, PHSPSplit.exe
     echo   - Libraries: libparticlezoo.lib, particlezoo.dll
     echo.
 )
@@ -200,6 +214,7 @@ if defined DO_INSTALL (
         copy "%OUTDIR%\PHSPConvert.exe" "%PREFIX%\bin" >nul
         copy "%OUTDIR%\PHSPCombine.exe" "%PREFIX%\bin" >nul
         copy "%OUTDIR%\PHSPImage.exe" "%PREFIX%\bin" >nul
+        copy "%OUTDIR%\PHSPSplit.exe" "%PREFIX%\bin" >nul
         copy "%OUTDIR%\particlezoo.dll" "%PREFIX%\bin" >nul
         copy "%OUTDIR%\%LIB_NAME%" "%PREFIX%\lib" >nul
         xcopy /E /I "include\particlezoo" "%PREFIX%\include\particlezoo" >nul

--- a/include/particlezoo/utilities/formats.h
+++ b/include/particlezoo/utilities/formats.h
@@ -40,12 +40,13 @@ namespace ParticleZoo
         static const std::vector<SupportedFormat> SupportedFormats();
 
         static std::unique_ptr<PhaseSpaceFileReader> CreateReader(const std::string& filename, const UserOptions & options = {});
-        static std::unique_ptr<PhaseSpaceFileReader> CreateReader(const std::string& name, const std::string& filename, const UserOptions & options = {});
+        static std::unique_ptr<PhaseSpaceFileReader> CreateReader(const std::string& formatName, const std::string& filename, const UserOptions & options = {});
 
         static std::unique_ptr<PhaseSpaceFileWriter> CreateWriter(const std::string& filename, const UserOptions & options = {}, const FixedValues & fixedValues = {});
-        static std::unique_ptr<PhaseSpaceFileWriter> CreateWriter(const std::string& name, const std::string& filename, const UserOptions & options = {}, const FixedValues & fixedValues = {});
+        static std::unique_ptr<PhaseSpaceFileWriter> CreateWriter(const std::string& formatName, const std::string& filename, const UserOptions & options = {}, const FixedValues & fixedValues = {});
 
         static std::vector<SupportedFormat> FormatsForExtension(const std::string& extension);
+        static const std::string ExtensionForFormat(const std::string& formatName);
 
         static void PrintSupportedFormats();
 

--- a/makefile
+++ b/makefile
@@ -77,6 +77,20 @@ GCC_SRCS_IMAGE := \
     src/ROOT/ROOTphsp.cc \
     PHSPImage.cc
 
+GCC_SRCS_SPLIT := \
+    src/PhaseSpaceFileReader.cc \
+    src/PhaseSpaceFileWriter.cc \
+    src/utilities/formats.cc \
+    src/utilities/argParse.cc \
+    src/egs/egsphspFile.cc \
+    src/peneasy/penEasyphspFile.cc \
+    src/IAEA/IAEAHeader.cc \
+    src/IAEA/IAEAphspFile.cc \
+    src/topas/TOPASHeader.cc \
+    src/topas/TOPASphspFile.cc \
+    src/ROOT/ROOTphsp.cc \
+    PHSPSplit.cc
+
 # --- static library settings ---
 LIB_NAME := libparticlezoo.a
 LIB_SRCS := \
@@ -122,56 +136,65 @@ endif
 CONVERT_BIN_REL := $(GCC_BIN_DIR_REL)/PHSPConvert$(BINEXT)
 COMBINE_BIN_REL := $(GCC_BIN_DIR_REL)/PHSPCombine$(BINEXT)
 IMAGE_BIN_REL   := $(GCC_BIN_DIR_REL)/PHSPImage$(BINEXT)
+SPLIT_BIN_REL   := $(GCC_BIN_DIR_REL)/PHSPSplit$(BINEXT)
 
 CONVERT_BIN_DBG := $(GCC_BIN_DIR_DBG)/PHSPConvert$(BINEXT)
 COMBINE_BIN_DBG := $(GCC_BIN_DIR_DBG)/PHSPCombine$(BINEXT)
 IMAGE_BIN_DBG   := $(GCC_BIN_DIR_DBG)/PHSPImage$(BINEXT)
+SPLIT_BIN_DBG   := $(GCC_BIN_DIR_DBG)/PHSPSplit$(BINEXT)
 
 # Make release the default goal
 .DEFAULT_GOAL := release
 
 .PHONY: release debug \
-        gcc-release-convert gcc-release-combine gcc-release-image gcc-release-lib \
-        gcc-debug-convert   gcc-debug-combine   gcc-debug-image gcc-debug-lib \
-        clean install install-debug
+		gcc-release-convert gcc-release-combine gcc-release-image gcc-release-split gcc-release-lib \
+		gcc-debug-convert   gcc-debug-combine   gcc-debug-image gcc-debug-split gcc-debug-lib \
+		clean install install-debug
 
 # Default (release)
-release: gcc-release-convert gcc-release-combine gcc-release-image gcc-release-lib
+release: gcc-release-convert gcc-release-combine gcc-release-image gcc-release-split gcc-release-lib
 
 # Debug bundle
-debug: gcc-debug-convert gcc-debug-combine gcc-debug-image gcc-debug-lib
+debug: gcc-debug-convert gcc-debug-combine gcc-debug-image gcc-debug-split gcc-debug-lib
 
 # Object lists for executables
 CONVERT_OBJS_REL := $(patsubst %.cc,$(GCC_BIN_DIR_REL)/%.o,$(GCC_SRCS_CONVERT))
 COMBINE_OBJS_REL := $(patsubst %.cc,$(GCC_BIN_DIR_REL)/%.o,$(GCC_SRCS_COMBINE))
 IMAGE_OBJS_REL   := $(patsubst %.cc,$(GCC_BIN_DIR_REL)/%.o,$(GCC_SRCS_IMAGE))
+SPLIT_OBJS_REL   := $(patsubst %.cc,$(GCC_BIN_DIR_REL)/%.o,$(GCC_SRCS_SPLIT))
 
 # Release executable targets
 gcc-release-convert: $(CONVERT_BIN_REL)
 gcc-release-combine: $(COMBINE_BIN_REL)
 gcc-release-image:   $(IMAGE_BIN_REL)
+gcc-release-split:   $(SPLIT_BIN_REL)
 
 $(CONVERT_BIN_REL): $(CONVERT_OBJS_REL)
 	@$(MKDIR_P) $(dir $@)
-	@echo "Linking Release (PHSPConvert)…"
+	@echo "Linking Release (PHSPConvert)..."
 	$(CXX) $(CXXFLAGS_RELEASE) $^ -o $@ $(ROOT_LIBS)
 	@echo " "
 
 $(COMBINE_BIN_REL): $(COMBINE_OBJS_REL)
 	@$(MKDIR_P) $(dir $@)
-	@echo "Linking Release (PHSPCombine)…"
+	@echo "Linking Release (PHSPCombine)..."
 	$(CXX) $(CXXFLAGS_RELEASE) $^ -o $@ $(ROOT_LIBS)
 
 $(IMAGE_BIN_REL): $(IMAGE_OBJS_REL)
 	@$(MKDIR_P) $(dir $@)
-	@echo "Linking Release (PHSPImage)…"
+	@echo "Linking Release (PHSPImage)..."
+	$(CXX) $(CXXFLAGS_RELEASE) $^ -o $@ $(ROOT_LIBS)
+   	
+$(SPLIT_BIN_REL): $(SPLIT_OBJS_REL)
+	@$(MKDIR_P) $(dir $@)
+	@echo "Linking Release (PHSPSplit)..."
 	$(CXX) $(CXXFLAGS_RELEASE) $^ -o $@ $(ROOT_LIBS)
 
 # Release static library
 gcc-release-lib: $(LIB_REL)
 $(LIB_REL): $(LIB_OBJS_REL)
 	@$(MKDIR_P) $(dir $@)
-	@echo "Building Release static library ($@)…"
+	@echo "Building Release static library ($@)..."
 	ar rcs $@ $^
 
 # Debug executable targets (could be parallelized similarly)
@@ -190,21 +213,26 @@ gcc-debug-image:
 	@echo "Building Debug (PHSPImage)..."
 	$(CXX) $(CXXFLAGS_DEBUG) $(GCC_SRCS_IMAGE) -o $(IMAGE_BIN_DBG) $(ROOT_LIBS)
 
+gcc-debug-split:
+	@$(MKDIR_P) $(GCC_BIN_DIR_DBG)
+	@echo "Building Debug (PHSPSplit)..."
+	$(CXX) $(CXXFLAGS_DEBUG) $(GCC_SRCS_SPLIT) -o $(SPLIT_BIN_DBG) $(ROOT_LIBS)
+
 gcc-debug-lib: $(LIB_DBG)
 $(LIB_DBG): $(LIB_OBJS_DBG)
 	@$(MKDIR_P) $(dir $@)
-	@echo "Building Debug static library ($@)…"
+	@echo "Building Debug static library ($@)..."
 	ar rcs $@ $^
 
 # --- compile object files into the right dirs ---
 $(GCC_BIN_DIR_REL)/%.o: %.cc
 	@$(MKDIR_P) $(dir $@)
-	@echo "Compiling Release object $<…"
+	@echo "Compiling Release object $<..."
 	$(CXX) $(CXXFLAGS_RELEASE) -c $< -o $@
 
 $(GCC_BIN_DIR_DBG)/%.o: %.cc
 	@$(MKDIR_P) $(dir $@)
-	@echo "Compiling Debug object $<…"
+	@echo "Compiling Debug object $<..."
 	$(CXX) $(CXXFLAGS_DEBUG) -c $< -o $@
 
 # Clean
@@ -221,7 +249,7 @@ LIBDIR := $(PREFIX)/lib
 install:
 	@printf "Installing into $(BINDIR), $(LIBDIR) and headers into $(PREFIX)/include..."
 	@$(MKDIR_P) $(BINDIR) $(LIBDIR) $(PREFIX)/include
-	@cp $(CONVERT_BIN_REL) $(COMBINE_BIN_REL) $(IMAGE_BIN_REL) $(BINDIR)
+	@cp $(CONVERT_BIN_REL) $(COMBINE_BIN_REL) $(IMAGE_BIN_REL) $(SPLIT_BIN_REL) $(BINDIR)
 	@cp $(LIB_REL) $(LIBDIR)
 	@cp -r $(PZ_HEADERS) $(PREFIX)/include
 	@echo " done."
@@ -229,14 +257,14 @@ install:
 install-debug:
 	@printf "Installing debug binaries and library to $(BINDIR), $(LIBDIR) and headers into $(PREFIX)/include..."
 	@$(MKDIR_P) $(BINDIR) $(LIBDIR) $(PREFIX)/include
-	@cp $(CONVERT_BIN_DBG) $(COMBINE_BIN_DBG) $(IMAGE_BIN_DBG) $(BINDIR)
+	@cp $(CONVERT_BIN_DBG) $(COMBINE_BIN_DBG) $(IMAGE_BIN_DBG) $(SPLIT_BIN_DBG) $(BINDIR)
 	@cp $(LIB_DBG) $(LIBDIR)
 	@cp -r $(PZ_HEADERS) $(PREFIX)/include
 	@echo " done."
 
 uninstall:
 	@printf "Removing particlezoo installation from $(PREFIX)..."
-	@rm -f $(BINDIR)/PHSPConvert$(BINEXT) $(BINDIR)/PHSPCombine$(BINEXT) $(BINDIR)/PHSPImage$(BINEXT)
+	@rm -f $(BINDIR)/PHSPConvert$(BINEXT) $(BINDIR)/PHSPCombine$(BINEXT) $(BINDIR)/PHSPImage$(BINEXT) $(BINDIR)/PHSPSplit$(BINEXT)
 	@rm -f $(LIBDIR)/$(LIB_NAME)
 	@rm -rf $(PREFIX)/include/particlezoo
 	@echo " done."

--- a/makefile
+++ b/makefile
@@ -147,9 +147,9 @@ SPLIT_BIN_DBG   := $(GCC_BIN_DIR_DBG)/PHSPSplit$(BINEXT)
 .DEFAULT_GOAL := release
 
 .PHONY: release debug \
-		gcc-release-convert gcc-release-combine gcc-release-image gcc-release-split gcc-release-lib \
-		gcc-debug-convert   gcc-debug-combine   gcc-debug-image gcc-debug-split gcc-debug-lib \
-		clean install install-debug
+        gcc-release-convert gcc-release-combine gcc-release-image gcc-release-split gcc-release-lib \
+        gcc-debug-convert   gcc-debug-combine   gcc-debug-image gcc-debug-split gcc-debug-lib \
+        clean install install-debug
 
 # Default (release)
 release: gcc-release-convert gcc-release-combine gcc-release-image gcc-release-split gcc-release-lib
@@ -157,11 +157,17 @@ release: gcc-release-convert gcc-release-combine gcc-release-image gcc-release-s
 # Debug bundle
 debug: gcc-debug-convert gcc-debug-combine gcc-debug-image gcc-debug-split gcc-debug-lib
 
-# Object lists for executables
+# Release object lists for executables
 CONVERT_OBJS_REL := $(patsubst %.cc,$(GCC_BIN_DIR_REL)/%.o,$(GCC_SRCS_CONVERT))
 COMBINE_OBJS_REL := $(patsubst %.cc,$(GCC_BIN_DIR_REL)/%.o,$(GCC_SRCS_COMBINE))
 IMAGE_OBJS_REL   := $(patsubst %.cc,$(GCC_BIN_DIR_REL)/%.o,$(GCC_SRCS_IMAGE))
 SPLIT_OBJS_REL   := $(patsubst %.cc,$(GCC_BIN_DIR_REL)/%.o,$(GCC_SRCS_SPLIT))
+
+# Debug object lists for executables
+CONVERT_OBJS_DBG := $(patsubst %.cc,$(GCC_BIN_DIR_DBG)/%.o,$(GCC_SRCS_CONVERT))
+COMBINE_OBJS_DBG := $(patsubst %.cc,$(GCC_BIN_DIR_DBG)/%.o,$(GCC_SRCS_COMBINE))
+IMAGE_OBJS_DBG   := $(patsubst %.cc,$(GCC_BIN_DIR_DBG)/%.o,$(GCC_SRCS_IMAGE))
+SPLIT_OBJS_DBG   := $(patsubst %.cc,$(GCC_BIN_DIR_DBG)/%.o,$(GCC_SRCS_SPLIT))
 
 # Release executable targets
 gcc-release-convert: $(CONVERT_BIN_REL)
@@ -184,7 +190,7 @@ $(IMAGE_BIN_REL): $(IMAGE_OBJS_REL)
 	@$(MKDIR_P) $(dir $@)
 	@echo "Linking Release (PHSPImage)..."
 	$(CXX) $(CXXFLAGS_RELEASE) $^ -o $@ $(ROOT_LIBS)
-   	
+
 $(SPLIT_BIN_REL): $(SPLIT_OBJS_REL)
 	@$(MKDIR_P) $(dir $@)
 	@echo "Linking Release (PHSPSplit)..."
@@ -198,25 +204,25 @@ $(LIB_REL): $(LIB_OBJS_REL)
 	ar rcs $@ $^
 
 # Debug executable targets (could be parallelized similarly)
-gcc-debug-convert:
+gcc-debug-convert: $(CONVERT_OBJS_DBG)
 	@$(MKDIR_P) $(GCC_BIN_DIR_DBG)
 	@echo "Building Debug (PHSPConvert)..."
-	$(CXX) $(CXXFLAGS_DEBUG) $(GCC_SRCS_CONVERT) -o $(CONVERT_BIN_DBG) $(ROOT_LIBS)
+	$(CXX) $(CXXFLAGS_DEBUG) $(CONVERT_OBJS_DBG) -o $(CONVERT_BIN_DBG) $(ROOT_LIBS)
 
-gcc-debug-combine:
+gcc-debug-combine: $(COMBINE_OBJS_DBG)
 	@$(MKDIR_P) $(GCC_BIN_DIR_DBG)
 	@echo "Building Debug (PHSPCombine)..."
-	$(CXX) $(CXXFLAGS_DEBUG) $(GCC_SRCS_COMBINE) -o $(COMBINE_BIN_DBG) $(ROOT_LIBS)
+	$(CXX) $(CXXFLAGS_DEBUG) $(COMBINE_OBJS_DBG) -o $(COMBINE_BIN_DBG) $(ROOT_LIBS)
 
-gcc-debug-image:
+gcc-debug-image: $(IMAGE_OBJS_DBG)
 	@$(MKDIR_P) $(GCC_BIN_DIR_DBG)
 	@echo "Building Debug (PHSPImage)..."
-	$(CXX) $(CXXFLAGS_DEBUG) $(GCC_SRCS_IMAGE) -o $(IMAGE_BIN_DBG) $(ROOT_LIBS)
+	$(CXX) $(CXXFLAGS_DEBUG) $(IMAGE_OBJS_DBG) -o $(IMAGE_BIN_DBG) $(ROOT_LIBS)
 
-gcc-debug-split:
+gcc-debug-split: $(SPLIT_OBJS_DBG)
 	@$(MKDIR_P) $(GCC_BIN_DIR_DBG)
 	@echo "Building Debug (PHSPSplit)..."
-	$(CXX) $(CXXFLAGS_DEBUG) $(GCC_SRCS_SPLIT) -o $(SPLIT_BIN_DBG) $(ROOT_LIBS)
+	$(CXX) $(CXXFLAGS_DEBUG) $(SPLIT_OBJS_DBG) -o $(SPLIT_BIN_DBG) $(ROOT_LIBS)
 
 gcc-debug-lib: $(LIB_DBG)
 $(LIB_DBG): $(LIB_OBJS_DBG)

--- a/src/PhaseSpaceFileReader.cc
+++ b/src/PhaseSpaceFileReader.cc
@@ -39,6 +39,7 @@ namespace ParticleZoo
             }()),
         bytesRead_(0),
         particlesRead_(0),
+        particlesSkipped_(0),
         historiesRead_(0),
         numberOfParticlesToRead_(0),
         particleRecordLength_(0),

--- a/src/PhaseSpaceFileReader.cc
+++ b/src/PhaseSpaceFileReader.cc
@@ -80,7 +80,7 @@ namespace ParticleZoo
             // Calculate byte offset to seek to
             std::size_t particleRecordStartOffset = getParticleRecordStartOffset();
             std::size_t particleRecordLength = getParticleRecordLength();
-            std::size_t bytesToSkip = particleRecordStartOffset + particleIndex * particleRecordLength;
+            std::size_t bytesToSkip = particleRecordStartOffset + static_cast<std::size_t>(particleIndex) * particleRecordLength;
 
             // Seek to the calculated position
             if (bytesToSkip + particleRecordLength > bytesInFile_) {

--- a/src/utilities/formats.cc
+++ b/src/utilities/formats.cc
@@ -151,13 +151,13 @@ namespace ParticleZoo
         return CreateReader(supportedFormats[0].name, filename, options);
     }
 
-    std::unique_ptr<PhaseSpaceFileReader> FormatRegistry::CreateReader(const std::string& name, const std::string& filename, const UserOptions & options)
+    std::unique_ptr<PhaseSpaceFileReader> FormatRegistry::CreateReader(const std::string& formatName, const std::string& filename, const UserOptions & options)
     {
         FormatRegistry& registry = instance();
         std::unique_lock lock(registry.mutex_);
-        auto it = registry.readerFactories_.find(name);
+        auto it = registry.readerFactories_.find(formatName);
         if (it == registry.readerFactories_.end()) {
-            throw std::runtime_error("Unsupported format: " + name);
+            throw std::runtime_error("Unsupported format: " + formatName);
         }
         return it->second(filename, options);
     }
@@ -176,13 +176,13 @@ namespace ParticleZoo
         return CreateWriter(supportedFormats[0].name, filename, options, fixedValues);
     }
 
-    std::unique_ptr<PhaseSpaceFileWriter> FormatRegistry::CreateWriter(const std::string& name, const std::string& filename, const UserOptions & options, const FixedValues & fixedValues)
+    std::unique_ptr<PhaseSpaceFileWriter> FormatRegistry::CreateWriter(const std::string& formatName, const std::string& filename, const UserOptions & options, const FixedValues & fixedValues)
     {
         FormatRegistry& registry = instance();
         std::unique_lock lock(registry.mutex_);
-        auto it = registry.writerFactories_.find(name);
+        auto it = registry.writerFactories_.find(formatName);
         if (it == registry.writerFactories_.end()) {
-            throw std::runtime_error("Unsupported format: " + name);
+            throw std::runtime_error("Unsupported format: " + formatName);
         }
         return it->second(filename, options, fixedValues);
     }
@@ -213,6 +213,17 @@ namespace ParticleZoo
             }
         }
         return result;
+    }
+
+    const std::string FormatRegistry::ExtensionForFormat(const std::string& formatName) {
+        auto& registry = FormatRegistry::instance();
+        std::unique_lock lock(registry.mutex_);
+        auto it = std::find_if(registry.formats_.begin(), registry.formats_.end(),
+            [&formatName](const SupportedFormat& f) { return f.name == formatName; });
+        if (it == registry.formats_.end()) {
+            throw std::runtime_error("Unsupported format: " + formatName);
+        }
+        return it->fileExtension;
     }
 
     void FormatRegistry::PrintSupportedFormats()


### PR DESCRIPTION
This pull request introduces a new command-line tool, `PHSPSplit`, for splitting phase space files into multiple roughly equally sized files respecting history boundaries, and integrates it into the build systems and documentation systems.